### PR TITLE
APIAPEX-2468: fix cli release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,13 +46,11 @@ jobs:
       - name: Set up Docker
         run: |
           brew install docker docker-machine docker-compose
-
           sudo mkdir -p /usr/local/bin 
           sudo curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.6.7/colima-Darwin-x86_64 && sudo chmod +x /usr/local/bin/colima
-          brew install lima
+          brew install lima lima-additional-guestagents
           brew install qemu
           colima start
-
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
 
       - name: Cache Go modules


### PR DESCRIPTION
should fix this: https://github.com/Vonage/cloud-runtime-cli/actions/runs/19326542870
