### PR TITLE
feat: add support instance list

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -22,6 +22,6 @@ jobs:
         run: |
           npm install --save-dev @commitlint/cli @commitlint/config-conventional
 
-      - name: Validate PR commits
+      - name: Validate PR title
         run: |
-          npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+          echo "${{ github.event.pull_request.title }}" | npx commitlint --verbose

--- a/pkg/api/datastore.go
+++ b/pkg/api/datastore.go
@@ -79,6 +79,57 @@ query MyQuery ($alias: String!) {
 	return resp.Data.Regions[0], nil
 }
 
+type listInstancesResponseData struct {
+	Instances []InstanceListItem `json:"Instances"`
+}
+
+type listInstancesResponse struct {
+	Data listInstancesResponseData `json:"data"`
+}
+
+type listInstancesParams struct {
+	ServiceName string `json:"service_name"`
+}
+
+// ListInstances lists all non-deleted instances ordered by last-updated date descending.
+// If filter is non-empty, only instances whose service_name contains the filter string
+// (case-insensitive) are returned, using a GraphQL _ilike operator.
+func (ds *Datastore) ListInstances(ctx context.Context, filter string) ([]InstanceListItem, error) {
+	const queryNoFilter = `
+query MyQuery {
+  Instances(order_by: {updated_at: desc}, where: {deleted: {_eq: false}}) {
+    id
+    api_application_id
+    name
+    service_name
+  }
+}`
+	const queryWithFilter = `
+query MyQuery ($service_name: String!) {
+  Instances(order_by: {updated_at: desc}, where: {deleted: {_eq: false}, service_name: {_ilike: $service_name}}) {
+    id
+    api_application_id
+    name
+    service_name
+  }
+}`
+	var req GQLRequest
+	if filter == "" {
+		req = GQLRequest{Query: queryNoFilter}
+	} else {
+		req = GQLRequest{
+			Query:     queryWithFilter,
+			Variables: listInstancesParams{ServiceName: "%" + filter + "%"},
+		}
+	}
+
+	var resp listInstancesResponse
+	if err := ds.gqlClient.Do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data.Instances, nil
+}
+
 type getByProjAndInstNameData struct {
 	Instances []Instance `json:"Instances"`
 }

--- a/pkg/api/datastore_test.go
+++ b/pkg/api/datastore_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -925,6 +926,156 @@ func TestListLogsByInstanceID(t *testing.T) {
 			}
 
 			require.Equal(t, tt.want.output, regions)
+			httpmock.Reset()
+		})
+	}
+}
+
+func TestListInstances(t *testing.T) {
+	httpClient := resty.New()
+	httpmock.ActivateNonDefault(httpClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	type mock struct {
+		mockResponse listInstancesResponse
+		status       int
+		respErr      error
+	}
+
+	type want struct {
+		output []InstanceListItem
+		err    error
+	}
+
+	tests := []struct {
+		name   string
+		filter string
+		mock   mock
+		want   want
+	}{
+		{
+			name:   "200-happy-path-no-filter",
+			filter: "",
+			mock: mock{
+				mockResponse: listInstancesResponse{
+					Data: listInstancesResponseData{
+						Instances: []InstanceListItem{
+							{
+								ID:               "11111111-1111-1111-1111-111111111111",
+								APIApplicationID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+								Name:             "dev",
+								ServiceName:      "my-service",
+							},
+							{
+								ID:               "22222222-2222-2222-2222-222222222222",
+								APIApplicationID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+								Name:             "prod",
+								ServiceName:      "my-service-prod",
+							},
+						},
+					},
+				},
+				status: http.StatusOK,
+			},
+			want: want{
+				output: []InstanceListItem{
+					{
+						ID:               "11111111-1111-1111-1111-111111111111",
+						APIApplicationID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+						Name:             "dev",
+						ServiceName:      "my-service",
+					},
+					{
+						ID:               "22222222-2222-2222-2222-222222222222",
+						APIApplicationID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+						Name:             "prod",
+						ServiceName:      "my-service-prod",
+					},
+				},
+			},
+		},
+		{
+			name:   "200-happy-path-with-filter",
+			filter: "prod",
+			mock: mock{
+				mockResponse: listInstancesResponse{
+					Data: listInstancesResponseData{
+						Instances: []InstanceListItem{
+							{
+								ID:               "22222222-2222-2222-2222-222222222222",
+								APIApplicationID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+								Name:             "prod",
+								ServiceName:      "my-service-prod",
+							},
+						},
+					},
+				},
+				status: http.StatusOK,
+			},
+			want: want{
+				output: []InstanceListItem{
+					{
+						ID:               "22222222-2222-2222-2222-222222222222",
+						APIApplicationID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+						Name:             "prod",
+						ServiceName:      "my-service-prod",
+					},
+				},
+			},
+		},
+		{
+			name:   "200-empty-result",
+			filter: "",
+			mock: mock{
+				mockResponse: listInstancesResponse{
+					Data: listInstancesResponseData{
+						Instances: []InstanceListItem{},
+					},
+				},
+				status: http.StatusOK,
+			},
+			want: want{
+				output: []InstanceListItem{},
+			},
+		},
+		{
+			name:   "transport-error",
+			filter: "",
+			mock:   mock{respErr: errors.New("transport error")},
+			want:   want{err: errors.New("transport error")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mock.respErr != nil {
+				httpmock.RegisterResponder("POST", "https://example.com",
+					httpmock.NewErrorResponder(tt.mock.respErr))
+			} else {
+				jsonData, err := json.Marshal(tt.mock.mockResponse)
+				if err != nil {
+					t.Fatalf("Error occurred during marshaling. Error: %s", err.Error())
+				}
+				httpmock.RegisterResponder("POST", "https://example.com",
+					func(_ *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(tt.mock.status, string(jsonData))
+						resp.Header.Set("Content-Type", "application/json")
+						return resp, nil
+					})
+			}
+
+			gqlClient := NewGraphQLClient("https://example.com", httpClient)
+			datastoreClient := NewDatastore(gqlClient)
+
+			output, err := datastoreClient.ListInstances(t.Context(), tt.filter)
+			if tt.want.err != nil {
+				require.Error(t, err)
+				httpmock.Reset()
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want.output, output)
 			httpmock.Reset()
 		})
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -18,6 +18,13 @@ type Instance struct {
 	ServiceName string `json:"service_name,omitempty"`
 }
 
+type InstanceListItem struct {
+	ID               string `json:"id"`
+	APIApplicationID string `json:"api_application_id"`
+	Name             string `json:"name"`
+	ServiceName      string `json:"service_name"`
+}
+
 type Runtime struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -63,6 +63,7 @@ type DatastoreInterface interface {
 	GetRegion(ctx context.Context, alias string) (api.Region, error)
 	GetInstanceByProjectAndInstanceName(ctx context.Context, projectName, instanceName string) (api.Instance, error)
 	GetInstanceByID(ctx context.Context, instanceID string) (api.Instance, error)
+	ListInstances(ctx context.Context, filter string) ([]api.InstanceListItem, error)
 	ListRuntimes(ctx context.Context) ([]api.Runtime, error)
 	GetRuntimeByName(ctx context.Context, name string) (api.Runtime, error)
 	GetProject(ctx context.Context, accountID, name string) (api.Project, error)

--- a/testutil/mocks/factory.go
+++ b/testutil/mocks/factory.go
@@ -656,6 +656,21 @@ func (mr *MockDatastoreInterfaceMockRecorder) ListLogsByInstanceID(ctx, instance
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLogsByInstanceID", reflect.TypeOf((*MockDatastoreInterface)(nil).ListLogsByInstanceID), ctx, instanceID, limit, timestamp)
 }
 
+// ListInstances mocks base method.
+func (m *MockDatastoreInterface) ListInstances(ctx context.Context, filter string) ([]api.InstanceListItem, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInstances", ctx, filter)
+	ret0, _ := ret[0].([]api.InstanceListItem)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListInstances indicates an expected call of ListInstances.
+func (mr *MockDatastoreInterfaceMockRecorder) ListInstances(ctx, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstances", reflect.TypeOf((*MockDatastoreInterface)(nil).ListInstances), ctx, filter)
+}
+
 // ListProducts mocks base method.
 func (m *MockDatastoreInterface) ListProducts(ctx context.Context) ([]api.Product, error) {
 	m.ctrl.T.Helper()

--- a/vcr/instance/instance.go
+++ b/vcr/instance/instance.go
@@ -27,6 +27,7 @@ func NewCmdInstance(f cmdutil.Factory) *cobra.Command {
 			  • A project name and instance name (from your manifest)
 
 			AVAILABLE COMMANDS
+			  list (ls)     List all deployed instances
 			  log (logs)    View real-time logs from a running instance
 			  remove (rm)   Delete an instance and free its resources
 
@@ -36,6 +37,12 @@ func NewCmdInstance(f cmdutil.Factory) *cobra.Command {
 			  • Project + Instance name: The combination from your vcr.yml manifest
 		`),
 		Example: heredoc.Doc(`
+			# List all instances
+			$ vcr instance list
+
+			# List instances filtered by service name
+			$ vcr instance list --filter "my-service"
+
 			# View logs for an instance by project and instance name
 			$ vcr instance log --project-name my-app --instance-name dev
 

--- a/vcr/instance/instance.go
+++ b/vcr/instance/instance.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"vonage-cloud-runtime-cli/pkg/cmdutil"
+	"vonage-cloud-runtime-cli/vcr/instance/list"
 	"vonage-cloud-runtime-cli/vcr/instance/log"
 	"vonage-cloud-runtime-cli/vcr/instance/remove"
 )
@@ -51,6 +52,7 @@ func NewCmdInstance(f cmdutil.Factory) *cobra.Command {
 
 	cmd.AddCommand(remove.NewCmdInstanceRemove(f))
 	cmd.AddCommand(log.NewCmdInstanceLog(f))
+	cmd.AddCommand(list.NewCmdInstanceList(f))
 
 	return cmd
 }

--- a/vcr/instance/list/list.go
+++ b/vcr/instance/list/list.go
@@ -1,0 +1,86 @@
+package list
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"vonage-cloud-runtime-cli/pkg/cmdutil"
+)
+
+type Options struct {
+	cmdutil.Factory
+
+	Filter string
+}
+
+func NewCmdInstanceList(f cmdutil.Factory) *cobra.Command {
+	opts := Options{
+		Factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all deployed VCR instances",
+		Long: heredoc.Doc(`List all deployed VCR instances.
+
+			This command displays a table of all non-deleted VCR instances, showing their
+			IDs, linked API application IDs, instance names and service names.
+		`),
+		Example: heredoc.Doc(`
+			# List all instances
+			$ vcr instance list
+			+--------------------------------------+--------------------------------------+---------------+--------------+
+			|             INSTANCE ID              |         API APPLICATION ID           | INSTANCE NAME | SERVICE NAME |
+			+--------------------------------------+--------------------------------------+---------------+--------------+
+			| 12345678-1234-1234-1234-123456789abc | 87654321-4321-4321-4321-cba987654321 | dev           | my-service   |
+			+--------------------------------------+--------------------------------------+---------------+--------------+
+
+			# List instances using the short alias
+			$ vcr instance ls
+
+			# Filter instances by service name
+			$ vcr instance list --filter "my-service"
+
+			# Filter with short flag
+			$ vcr instance list -f "prod"
+		`),
+		Args: cobra.MaximumNArgs(0),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithDeadline(context.Background(), opts.Deadline())
+			defer cancel()
+
+			return runList(ctx, &opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Filter, "filter", "f", "", "Filter instances by service name (case-insensitive substring match)")
+
+	return cmd
+}
+
+func runList(ctx context.Context, opts *Options) error {
+	io := opts.IOStreams()
+
+	spinner := cmdutil.DisplaySpinnerMessageWithHandle(" Fetching instances list...")
+	instances, err := opts.Datastore().ListInstances(ctx, opts.Filter)
+	spinner.Stop()
+	if err != nil {
+		return fmt.Errorf("failed to list instances: %w", err)
+	}
+
+	table := tablewriter.NewWriter(io.Out)
+	table.Header("Instance ID", "API Application ID", "Instance Name", "Service Name")
+
+	for _, inst := range instances {
+		if err := table.Append([]string{inst.ID, inst.APIApplicationID, inst.Name, inst.ServiceName}); err != nil {
+			return fmt.Errorf("failed to append instance to table: %w", err)
+		}
+	}
+
+	return table.Render()
+}

--- a/vcr/instance/list/list_test.go
+++ b/vcr/instance/list/list_test.go
@@ -1,0 +1,182 @@
+package list
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/golang/mock/gomock"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/require"
+
+	"vonage-cloud-runtime-cli/pkg/api"
+	"vonage-cloud-runtime-cli/pkg/cmdutil"
+	"vonage-cloud-runtime-cli/testutil"
+	"vonage-cloud-runtime-cli/testutil/mocks"
+)
+
+func runCommand(t *testing.T, datastoreMock cmdutil.DatastoreInterface, cli string) (*testutil.CmdOut, error) {
+	t.Helper()
+
+	ios, _, stdout, stderr := iostreams.Test()
+
+	argv, err := shlex.Split(cli)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f := testutil.DefaultFactoryMock(t, ios, nil, nil, datastoreMock, nil, nil, nil)
+
+	cmd := NewCmdInstanceList(f)
+	cmd.SetArgs(argv)
+	cmd.SetIn(&bytes.Buffer{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	if _, err := cmd.ExecuteC(); err != nil {
+		return nil, err
+	}
+
+	return &testutil.CmdOut{
+		OutBuf: stdout,
+		ErrBuf: stderr,
+	}, nil
+}
+
+func TestInstanceList(t *testing.T) {
+	type mock struct {
+		ListTimes           int
+		ListWantFilter      string
+		ListReturnInstances []api.InstanceListItem
+		ListReturnErr       error
+	}
+	type want struct {
+		errMsg   string
+		contains []string
+	}
+
+	tests := []struct {
+		name string
+		cli  string
+		mock mock
+		want want
+	}{
+		{
+			name: "happy-path",
+			cli:  "",
+			mock: mock{
+				ListTimes:      1,
+				ListWantFilter: "",
+				ListReturnInstances: []api.InstanceListItem{
+					{
+						ID:               "11111111-1111-1111-1111-111111111111",
+						APIApplicationID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+						Name:             "dev",
+						ServiceName:      "my-service",
+					},
+					{
+						ID:               "22222222-2222-2222-2222-222222222222",
+						APIApplicationID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+						Name:             "prod",
+						ServiceName:      "my-service-prod",
+					},
+				},
+			},
+			want: want{
+				contains: []string{
+					"INSTANCE ID",
+					"API APPLICATION ID",
+					"INSTANCE NAME",
+					"SERVICE NAME",
+					"11111111-1111-1111-1111-111111111111",
+					"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					"dev",
+					"my-service",
+					"22222222-2222-2222-2222-222222222222",
+					"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+					"prod",
+					"my-service-prod",
+				},
+			},
+		},
+		{
+			name: "with-filter",
+			cli:  "--filter=prod",
+			mock: mock{
+				ListTimes:      1,
+				ListWantFilter: "prod",
+				ListReturnInstances: []api.InstanceListItem{
+					{
+						ID:               "22222222-2222-2222-2222-222222222222",
+						APIApplicationID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+						Name:             "prod",
+						ServiceName:      "my-service-prod",
+					},
+				},
+			},
+			want: want{
+				contains: []string{
+					"INSTANCE ID",
+					"API APPLICATION ID",
+					"INSTANCE NAME",
+					"SERVICE NAME",
+					"22222222-2222-2222-2222-222222222222",
+					"my-service-prod",
+				},
+			},
+		},
+		{
+			name: "no-items",
+			cli:  "",
+			mock: mock{
+				ListTimes:           1,
+				ListWantFilter:      "",
+				ListReturnInstances: []api.InstanceListItem{},
+			},
+			want: want{
+				contains: []string{
+					"INSTANCE ID",
+					"API APPLICATION ID",
+					"INSTANCE NAME",
+					"SERVICE NAME",
+				},
+			},
+		},
+		{
+			name: "with-api-error",
+			cli:  "",
+			mock: mock{
+				ListTimes:     1,
+				ListReturnErr: errors.New("api error"),
+			},
+			want: want{
+				errMsg: "failed to list instances: api error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			datastoreMock := mocks.NewMockDatastoreInterface(ctrl)
+			datastoreMock.EXPECT().
+				ListInstances(gomock.Any(), tt.mock.ListWantFilter).
+				Times(tt.mock.ListTimes).
+				Return(tt.mock.ListReturnInstances, tt.mock.ListReturnErr)
+
+			cmdOut, err := runCommand(t, datastoreMock, tt.cli)
+			if tt.want.errMsg != "" {
+				require.Error(t, err, "should throw error")
+				require.Equal(t, tt.want.errMsg, err.Error())
+				return
+			}
+			require.NoError(t, err, "should not throw error")
+			for _, s := range tt.want.contains {
+				require.Contains(t, cmdOut.String(), s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow listing all deployed and not removed instances. Add the possibility to use filters for the service_name. 

Usages:
```bash
vcr instance list
vcr instance list --filter="my-app"
```

The output:
```bash

┌──────────────────────────────────────┬──────────────────────────────────────┬───────────────┬──────────────────────────────────────────────────┐
│             INSTANCE ID              │          API APPLICATION ID          │ INSTANCE NAME │                   SERVICE NAME                   │
├──────────────────────────────────────┼──────────────────────────────────────┼───────────────┼──────────────────────────────────────────────────┤
│ d8ad9b24-f7fc-4e06-8c1d-a252c03d3651 │ d8ad9b24-f7fc-4e06-8c1d-a252c03d3655 │ dev           │ neru-abc12345-my-app-1                           │
│ d8ad9b24-f7fc-4e06-8c1d-a252c03d3652 │ d8ad9b24-f7fc-4e06-8c1d-a252c03d3656 │ prod          │ neru-abc12345-my-app-2                           │
│ d8ad9b24-f7fc-4e06-8c1d-a252c03d3653 │ d8ad9b24-f7fc-4e06-8c1d-a252c03d3657 │ dev           │ neru-abc12345-my-app-3                           │
│ d8ad9b24-f7fc-4e06-8c1d-a252c03d3654 │ d8ad9b24-f7fc-4e06-8c1d-a252c03d3658 │ dev           │ neru-abc12345-my-app-4                           │
└──────────────────────────────────────┴──────────────────────────────────────┴───────────────┴──────────────────────────────────────────────────┘
```